### PR TITLE
Add HUD statistics display and result logging

### DIFF
--- a/env_survival.py
+++ b/env_survival.py
@@ -38,6 +38,7 @@ class SurvivalEnv:
         self.wolf: Pos = (0,0)
         self.hp: int = cfg.HP_MAX
         self.preys: List[Prey] = []
+        self.preys_eaten: int = 0
 
         # spawn scheduler (délai croissant)
         self._spawn_interval: float = float(cfg.SPAWN_INTERVAL_START)
@@ -54,6 +55,7 @@ class SurvivalEnv:
         self.tick = 0
         self.hp = self.cfg.HP_MAX
         self.preys = []
+        self.preys_eaten = 0
 
         # place wolf
         self.wolf = (self.rng.integers(0, self.n), self.rng.integers(0, self.n))
@@ -99,6 +101,7 @@ class SurvivalEnv:
         if healed:
             heal = int(round(self.cfg.EAT_HEAL_FRAC * self.cfg.HP_MAX)) * healed
             self.hp = min(self.cfg.HP_MAX, self.hp + heal)
+            self.preys_eaten += healed
 
     # --- Preys movement (1 tick sur 2) ---
     def _preys_step(self):

--- a/game_results.csv
+++ b/game_results.csv
@@ -1,0 +1,1 @@
+timestamp,score,survival_ticks,survival_seconds

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from config import Config
 from env_survival import SurvivalEnv
 from renderer import Renderer
 from wolf_policy import choose_next_pos
+from results_logger import log_result
 
 
 def run():
@@ -42,8 +43,9 @@ def run():
                 # step environnement
                 done = env.step()
                 if done:
-                    # petit écran de fin
-                    print("[GAME OVER] ticks=", env.tick)
+                    # petit écran de fin + sauvegarde des stats
+                    log_result(env.preys_eaten, env.tick, cfg.FPS)
+                    print(f"[GAME OVER] ticks={env.tick} score={env.preys_eaten}")
                     pygame.time.wait(800)
                     return
 

--- a/renderer.py
+++ b/renderer.py
@@ -20,7 +20,7 @@ class Renderer:
         pygame.init()
         self.cell = cfg.CELL
         self.w = env.n * self.cell
-        self.h = env.n * self.cell + 40  # bandeau HUD
+        self.h = env.n * self.cell + 70  # bandeau HUD élargi pour les infos
         self.screen = pygame.display.set_mode((self.w, self.h))
         pygame.display.set_caption("Survival Wolf")
         self.clock = pygame.time.Clock()
@@ -52,15 +52,31 @@ class Renderer:
 
         # HUD
         hud_y = self.env.n * self.cell
-        pygame.draw.rect(scr, (16,16,18), (0, hud_y, self.w, 40))
-        # HP bar
-        hp_frac = self.env.hp / self.cfg.HP_MAX
-        pygame.draw.rect(scr, (60,60,70), (10, hud_y+10, self.w-20, 20))
-        pygame.draw.rect(scr, (220,120,40), (10, hud_y+10, int((self.w-20) * hp_frac), 20))
-        # texte
-        txt = f"tick={self.env.tick}  hp={self.env.hp}/{self.cfg.HP_MAX}  preys={len(self.env.preys)}  next_spawn≈{getattr(self.env, '_next_spawn_tick', 0)}"
+        hud_height = 70
+        stats_height = 26
+        bar_height = 20
+        pygame.draw.rect(scr, (16,16,18), (0, hud_y, self.w, hud_height))
+
+        # zone texte au-dessus de la barre de vie
+        next_spawn_tick = getattr(self.env, "_next_spawn_tick", 0)
+        spawn_in = max(0, next_spawn_tick - self.env.tick)
+        surv_seconds = self.env.tick / self.cfg.FPS if self.cfg.FPS else float(self.env.tick)
+        txt = (
+            f"Score: {getattr(self.env, 'preys_eaten', 0)}    "
+            f"Survie: {surv_seconds:5.1f}s    "
+            f"Next spawn: {next_spawn_tick} (dans {spawn_in} ticks)"
+        )
         surf = self.font.render(txt, True, (220,220,230))
-        scr.blit(surf, (12, hud_y+10))
+        scr.blit(surf, (12, hud_y + 6))
+
+        # HP bar
+        hp_frac = 0.0 if self.cfg.HP_MAX == 0 else self.env.hp / self.cfg.HP_MAX
+        bar_y = hud_y + stats_height + 10
+        pygame.draw.rect(scr, (60,60,70), (10, bar_y, self.w-20, bar_height))
+        pygame.draw.rect(scr, (220,120,40), (10, bar_y, int((self.w-20) * hp_frac), bar_height))
+        hp_txt = f"HP: {self.env.hp}/{self.cfg.HP_MAX}"
+        hp_surf = self.font.render(hp_txt, True, (15,15,18))
+        scr.blit(hp_surf, (14, bar_y + 2))
 
         pygame.display.flip()
 

--- a/results_logger.py
+++ b/results_logger.py
@@ -1,0 +1,36 @@
+"""Utility to persist survival game results."""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Final
+
+RESULTS_FILE: Final[Path] = Path("game_results.csv")
+
+
+def log_result(score: int, survival_ticks: int, fps: int) -> None:
+    """Append the run results to the CSV file.
+
+    Parameters
+    ----------
+    score: int
+        Total number of preys eaten during the run.
+    survival_ticks: int
+        Lifetime expressed in simulation ticks.
+    fps: int
+        Frames per second used for rendering, to convert ticks into seconds.
+    """
+    survival_seconds = survival_ticks / fps if fps else float(survival_ticks)
+    header = "timestamp,score,survival_ticks,survival_seconds\n"
+    line = (
+        f"{datetime.now().isoformat(timespec='seconds')},"
+        f"{score},"
+        f"{survival_ticks},"
+        f"{survival_seconds:.2f}\n"
+    )
+
+    file_exists = RESULTS_FILE.exists()
+    with RESULTS_FILE.open("a", encoding="utf-8") as log_file:
+        if not file_exists:
+            log_file.write(header)
+        log_file.write(line)


### PR DESCRIPTION
## Summary
- track the number of preys eaten so the environment can report a score
- expand the HUD to show score, survival time, and next spawn information above the health bar
- persist the final score and survival duration to a CSV log at the end of each run

## Testing
- python -m py_compile env_survival.py renderer.py main.py results_logger.py

------
https://chatgpt.com/codex/tasks/task_e_68dd79a45724832391c1aea41a7b6f36