### PR TITLE
Refactor prey logic and add mode selection prompt

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,5 +1,3 @@
-## config.py
-
 from dataclasses import dataclass
 
 
@@ -7,24 +5,28 @@ from dataclasses import dataclass
 class Config:
     GRID_SIZE: int = 60
     N_PREYS_START: int = 21
-    PREY_MOVE_PROB: float = 0.80 # proba de bouger lors des ticks actifs
-    PREY_MOVES_EVERY_OTHER_TICK: bool = True # proies ne bougent qu’un tick sur deux
-    
-    
+    PREY_MOVE_PROB: float = 0.80  # proba de bouger lors des ticks actifs
+    PREY_MOVES_EVERY_OTHER_TICK: bool = True  # proies ne bougent qu’un tick sur deux
+
     HP_MAX: int = 100
     HP_DECAY_PER_TICK: float = 0.8
+    HP_DECAY_STATIC: float = 0.4
+    HP_DECAY_MOVING: float = 0.8
     EAT_HEAL_MISSING_FRACTION: float = 0.6  # portion de la vie manquante rendue en mangeant
 
-    
-    
-    SPAWN_INTERVAL_START: int = 25 # ticks entre spawns au début
-    SPAWN_INTERVAL_GROWTH: float = 1.1 # facteur multiplicatif après chaque spawn
+    SPAWN_INTERVAL_START: int = 25  # ticks entre spawns au début
+    SPAWN_INTERVAL_GROWTH: float = 1.1  # facteur multiplicatif après chaque spawn
     MAX_PREYS: int = 80
-    
-    
+
+    TTL_STATIC: int = 120
+    TTL_ERRATIC: int = 80
+    TTL_FLEE: int = 50
+    FLEE_MOVE_PERIOD: int = 5
+    FLEE_MOVE_REST_PHASE: int = 0
+    FLEE_RADIUS: int = 8
+
     RNG_SEED: int | None = None
-    
-    
+
     # Rendu
     CELL: int = 12
     SHOW_GRID: bool = True

--- a/env2_survival.py
+++ b/env2_survival.py
@@ -1,70 +1,16 @@
-# env2_survival.py
 from __future__ import annotations
-from dataclasses import dataclass
-from typing import List, Tuple, Optional
+
+from typing import Optional, Tuple
+
 import numpy as np
+
 from config import Config
-
-Pos = Tuple[int, int]
-DIRS_8 = [(0,-1),(1,-1),(1,0),(1,1),(0,1),(-1,1),(-1,0),(-1,-1)]
-STAY = (0,0)
-
-# Types de proies
-PREY_STATIC  = 0  # +1 pt
-PREY_ERRATIC = 1  # +2 pts
-PREY_FLEE    = 2  # +3 pts
-
-PREY_POINTS = {
-    PREY_STATIC: 1,
-    PREY_ERRATIC: 2,
-    PREY_FLEE: 3,
-}
-
-# Cadence des fuyantes : bougent 4 ticks sur 5
-FLEE_MOVE_PERIOD = 5        # période de 5 ticks
-FLEE_MOVE_REST_PHASE = 0    # repos quand (tick % 5) == 0  -> 4/5 actifs
-
-FLEE_RADIUS = 8  # distance de Tchebychev pour déclencher la fuite
+from preys import AdvancedPreyLogic, Pos
 
 
-def in_bounds(p: Pos, n: int) -> bool:
-    return 0 <= p[0] < n and 0 <= p[1] < n
+class SurvivalEnvV2:
+    """Advanced survival environment relying on :mod:`preys` for prey behaviour."""
 
-
-def cheb(a: Pos, b: Pos) -> int:
-    return max(abs(a[0]-b[0]), abs(a[1]-b[1]))
-
-
-def sign(x: int) -> int:
-    return 0 if x == 0 else (1 if x > 0 else -1)
-
-
-@dataclass
-class Prey:
-    pos: Pos
-    ptype: int     # PREY_STATIC / PREY_ERRATIC / PREY_FLEE
-    ttl: int       # ticks restants avant disparition
-
-
-class SurvivalEnv:
-    """
-    env2 — ajout TTL et double décay HP (repos vs mouvement).
-
-    - 3 types de proies (1/3 chacun, spawns cycliques):
-        STATIC (+1 pt)    : ne bouge pas.
-        ERRATIC (+2 pts)  : marche aléatoire (stay+8 voisins).
-        FLEE (+3 pts)     : comme ERRATIC tant que le loup est loin ; si dist <= 6, fuit (1 pas)
-                            à l'opposé ; si bord, dévie perpendiculairement (choix aléatoire si besoin).
-    - TTL : chaque proie a un temps de vie (plus court pour +3). À 0 -> disparition.
-    - HP decay : deux constantes
-        * HP_DECAY_STATIC : quand le loup NE bouge PAS ce tick
-        * HP_DECAY_MOVING : quand le loup a bougé ce tick
-      (fallback si non présents: on dérive depuis HP_DECAY_PER_TICK.)
-    - Score : +1/+2/+3 à la capture selon le type.
-    - Heal : identique (via EAT_HEAL_MISSING_FRACTION).
-    - Mouvement des proies : respecte PREY_MOVES_EVERY_OTHER_TICK et PREY_MOVE_PROB.
-    - La dynamique du loup est externe: appeler set_wolf() avant step().
-    """
     def __init__(self, cfg: Config):
         self.cfg = cfg
         self.n = cfg.GRID_SIZE
@@ -72,98 +18,36 @@ class SurvivalEnv:
 
         self.tick: int = 0
         self.wolf: Pos = (0, 0)
-        self._wolf_prev: Pos = (0, 0)  # pour savoir si le loup a bougé ce tick
+        self._wolf_prev: Pos = (0, 0)
         self.hp: float = float(cfg.HP_MAX)
-        self.preys: List[Prey] = []
+        self.score: int = 0
         self._ate_this_tick: bool = False
 
-        self.score: int = 0
+        self.prey_logic = AdvancedPreyLogic(cfg, self.rng)
+        self.preys = self.prey_logic.preys
 
-        # Spawn cyclique
-        self._spawn_cycle = [PREY_STATIC, PREY_ERRATIC, PREY_FLEE]
-        self._spawn_idx = 0
+        self._next_spawn_tick: int = self.prey_logic.next_spawn_tick
 
-        # Scheduler de spawn (délai croissant)
-        self._spawn_interval: float = float(cfg.SPAWN_INTERVAL_START)
-        self._next_spawn_tick: int = int(self._spawn_interval)
-
-        # TTL par type (fallback si non défini dans Config)
-        self._ttl_static  = int(getattr(cfg, "TTL_STATIC", 120))
-        self._ttl_erratic = int(getattr(cfg, "TTL_ERRATIC", 80))
-        self._ttl_flee    = int(getattr(cfg, "TTL_FLEE", 50))
-
-        # Décay HP (fallbacks)
-        base_decay = float(getattr(cfg, "HP_DECAY_PER_TICK", 0.35))
-        self._decay_static = float(getattr(cfg, "HP_DECAY_STATIC", base_decay * 0.5))
-        self._decay_moving = float(getattr(cfg, "HP_DECAY_MOVING", base_decay))
-
-    # -------- API externe (contrôle du loup) --------
-    def set_wolf(self, pos: Pos):
+    def set_wolf(self, pos: Pos) -> None:
         x = max(0, min(self.n - 1, int(pos[0])))
         y = max(0, min(self.n - 1, int(pos[1])))
         self.wolf = (x, y)
 
-    # -------- Reset --------
-    def reset(self):
+    def reset(self) -> None:
         self.tick = 0
         self.hp = float(self.cfg.HP_MAX)
-        self.preys = []
-        self._ate_this_tick = False
         self.score = 0
+        self._ate_this_tick = False
 
-        # place wolf
         self.wolf = (self.rng.integers(0, self.n), self.rng.integers(0, self.n))
         self._wolf_prev = self.wolf
+        self.prey_logic.reset(self.wolf)
+        self._next_spawn_tick = self.prey_logic.next_spawn_tick
 
-        # place initial preys (en respectant l'ordre cyclique)
-        occ = {self.wolf}
-        for _ in range(self.cfg.N_PREYS_START):
-            p = self._sample_free_cell(occ)
-            if p is None:
-                break
-            ptype = self._spawn_cycle[self._spawn_idx]
-            self._spawn_idx = (self._spawn_idx + 1) % len(self._spawn_cycle)
-            ttl = self._initial_ttl_for(ptype)
-            self.preys.append(Prey(p, ptype, ttl))
-            occ.add(p)
+    def nearest_prey(self, pos: Optional[Pos] = None) -> Tuple[int, Optional[Pos]]:
+        return self.prey_logic.nearest_prey(self.wolf, pos)
 
-        # reset spawn schedule
-        self._spawn_interval = float(self.cfg.SPAWN_INTERVAL_START)
-        self._next_spawn_tick = int(self._spawn_interval)
-
-    # -------- Helpers --------
-    def _initial_ttl_for(self, ptype: int) -> int:
-        if ptype == PREY_STATIC:
-            return self._ttl_static
-        elif ptype == PREY_ERRATIC:
-            return self._ttl_erratic
-        else:
-            return self._ttl_flee
-
-    def _sample_free_cell(self, occ: set) -> Optional[Pos]:
-        tries = 0
-        while tries < 400:
-            tries += 1
-            p = (self.rng.integers(0, self.n), self.rng.integers(0, self.n))
-            if p not in occ:
-                return p
-        return None
-
-    def nearest_prey(self, pos: Optional[Pos] = None) -> tuple[int, Optional[Pos]]:
-        if pos is None:
-            pos = self.wolf
-        if not self.preys:
-            return (10**9, None)
-        best_d = 10**9
-        best_p: Optional[Pos] = None
-        for pr in self.preys:
-            d = cheb(pos, pr.pos)
-            if d < best_d:
-                best_d, best_p = d, pr.pos
-        return best_d, best_p
-
-    # -------- Eating --------
-    def _apply_heal(self):
+    def _apply_heal(self) -> None:
         missing = float(self.cfg.HP_MAX) - self.hp
         if missing <= 0:
             return
@@ -172,193 +56,38 @@ class SurvivalEnv:
             return
         self.hp = min(float(self.cfg.HP_MAX), self.hp + heal)
 
-    def _eat_if_in_reach(self):
-        """Mange au plus une proie adjacente (Chebyshev <= 1), ajoute le score selon le type."""
+    def _eat_if_in_reach(self) -> None:
         if self._ate_this_tick:
             return
-        for idx, prey in enumerate(self.preys):
-            if cheb(self.wolf, prey.pos) <= 1:
-                # retire la proie
-                self.preys.pop(idx)
-                # heal
-                self._apply_heal()
-                # score
-                self.score += PREY_POINTS.get(prey.ptype, 1)
-                self._ate_this_tick = True
-                break
-
-    # -------- Mouvement des proies --------
-    def _preys_step(self):
-        wolf_cell = self.wolf
-        n = self.n
-    
-        # Occupation actuelle
-        occupied = {pr.pos for pr in self.preys}
-        order = list(range(len(self.preys)))
-        self.rng.shuffle(order)
-    
-        for idx in order:
-            pr = self.preys[idx]
-            start = pr.pos
-    
-            if pr.ptype == PREY_STATIC:
-                # ne bouge pas
-                continue
-    
-            # --- Cadence de mouvement selon le type ---
-            if pr.ptype == PREY_ERRATIC:
-                # erratiques : respectent éventuellement le mode "1 tick sur 2"
-                if self.cfg.PREY_MOVES_EVERY_OTHER_TICK and (self.tick % 2 == 1):
-                    continue
-            else:
-                # fuyantes : bougent 4/5 (repos sur les ticks où (tick % 5) == FLEE_MOVE_REST_PHASE)
-                if (self.tick % FLEE_MOVE_PERIOD) == FLEE_MOVE_REST_PHASE:
-                    continue
-    
-            # Probabilité de bouger (commune erratique/fuyante)
-            if self.rng.random() >= self.cfg.PREY_MOVE_PROB:
-                continue
-    
-            # On libère sa case de départ (on va tenter de bouger)
-            occupied.discard(start)
-    
-            if pr.ptype == PREY_ERRATIC:
-                new_pos = self._step_erratic(start, wolf_cell, occupied, n)
-            else:  # PREY_FLEE
-                if cheb(start, wolf_cell) <= FLEE_RADIUS:
-                    new_pos = self._step_flee(start, wolf_cell, occupied, n)
-                else:
-                    # hors rayon: se comporte comme ERRATIC
-                    new_pos = self._step_erratic(start, wolf_cell, occupied, n)
-    
-            # Appliquer le mouvement
-            if new_pos is None:
-                # pas de case dispo -> rester sur place si possible
-                if start != wolf_cell and start not in occupied:
-                    pr.pos = start
-                    occupied.add(start)
-                else:
-                    # fallback: essayer une case voisine libre quelconque
-                    candidates = [(start[0]+dx, start[1]+dy) for dx,dy in ([STAY]+DIRS_8)]
-                    candidates = [c for c in candidates if in_bounds(c, n) and c != wolf_cell and c not in occupied]
-                    if candidates:
-                        choice = candidates[self.rng.integers(0, len(candidates))]
-                        pr.pos = choice
-                        occupied.add(choice)
-                    else:
-                        pr.pos = start
-                        occupied.add(start)
-            else:
-                pr.pos = new_pos
-                occupied.add(new_pos)
-
-
-    def _step_erratic(self, start: Pos, wolf: Pos, occupied: set, n: int) -> Optional[Pos]:
-        # Random parmi stay+8 voisins, borné, sans collision, pas sur le loup
-        candidates = [(start[0]+dx, start[1]+dy) for dx,dy in ([STAY] + DIRS_8)]
-        candidates = [c for c in candidates if in_bounds(c, n) and c != wolf and c not in occupied]
-        if not candidates:
-            return None
-        return candidates[self.rng.integers(0, len(candidates))]
-
-    def _step_flee(self, start: Pos, wolf: Pos, occupied: set, n: int) -> Optional[Pos]:
-        # Vecteur de fuite (à l'opposé du loup), 1 pas
-        vx = sign(start[0] - wolf[0])
-        vy = sign(start[1] - wolf[1])
-        if vx == 0 and vy == 0:
-            return self._step_erratic(start, wolf, occupied, n)
-
-        primary = (start[0] + vx, start[1] + vy)
-        if in_bounds(primary, n) and primary not in occupied and primary != wolf:
-            return primary
-
-        # Déviation perpendiculaire si bord
-        candidates: List[Pos] = []
-        if not in_bounds((start[0] + vx, start[1]), n):
-            for vy2 in (-1, 1):
-                alt = (start[0], start[1] + vy2)
-                if in_bounds(alt, n) and alt not in occupied and alt != wolf:
-                    candidates.append(alt)
-        if not in_bounds((start[0], start[1] + vy), n):
-            for vx2 in (-1, 1):
-                alt = (start[0] + vx2, start[1])
-                if in_bounds(alt, n) and alt not in occupied and alt != wolf:
-                    candidates.append(alt)
-
-        if candidates:
-            return candidates[self.rng.integers(0, len(candidates))]
-
-        # Sinon: essayer d'augmenter la distance
-        better = []
-        same = []
-        d0 = cheb(start, wolf)
-        for dx, dy in DIRS_8 + [STAY]:
-            alt = (start[0] + dx, start[1] + dy)
-            if not in_bounds(alt, n) or alt == wolf or alt in occupied:
-                continue
-            d = cheb(alt, wolf)
-            if d > d0:
-                better.append(alt)
-            elif d == d0:
-                same.append(alt)
-        pool = better if better else same
-        if pool:
-            return pool[self.rng.integers(0, len(pool))]
-        return None
-
-    # -------- TTL & Spawns --------
-    def _decrement_and_purge_ttl(self):
-        """Décrémente le TTL de chaque proie et supprime celles qui expirent avant toute autre action."""
-        i = 0
-        while i < len(self.preys):
-            self.preys[i].ttl -= 1
-            if self.preys[i].ttl <= 0:
-                self.preys.pop(i)
-            else:
-                i += 1
-
-    def _maybe_spawn(self):
-        if len(self.preys) >= self.cfg.MAX_PREYS:
+        prey = self.prey_logic.eat_if_in_reach(self.wolf)
+        if prey is None:
             return
-        if self.tick >= self._next_spawn_tick:
-            occ = {self.wolf, *(pr.pos for pr in self.preys)}
-            p = self._sample_free_cell(occ)
-            if p is not None:
-                ptype = self._spawn_cycle[self._spawn_idx]
-                self._spawn_idx = (self._spawn_idx + 1) % len(self._spawn_cycle)
-                ttl = self._initial_ttl_for(ptype)
-                self.preys.append(Prey(p, ptype, ttl))
-            # planifier prochain spawn (délai croissant)
-            self._spawn_interval = max(1.0, self._spawn_interval * self.cfg.SPAWN_INTERVAL_GROWTH)
-            self._next_spawn_tick = self.tick + int(round(self._spawn_interval))
+        self._apply_heal()
+        self.score += prey.score_value
+        self._ate_this_tick = True
 
-    # -------- Step --------
-    def step(self):
+    def step(self) -> bool:
         self.tick += 1
         self._ate_this_tick = False
 
-        # 0) TTL : décrémente et purge d'abord
-        self._decrement_and_purge_ttl()
+        self.prey_logic.before_step()
 
-        # 1) Décay HP en fonction du mouvement ce tick
-        moved = (self.wolf != self._wolf_prev)
-        self.hp = max(0.0, self.hp - (self._decay_moving if moved else self._decay_static))
-        self._wolf_prev = self.wolf  # mémoriser la position utilisée ce tick
+        moved = self.wolf != self._wolf_prev
+        decay = self.cfg.HP_DECAY_MOVING if moved else self.cfg.HP_DECAY_STATIC
+        self.hp = max(0.0, self.hp - decay)
+        self._wolf_prev = self.wolf
 
-        # 2) Manger AVANT déplacement (si encore vivant)
         if self.hp > 0.0:
             self._eat_if_in_reach()
 
-        # 3) Déplacement des proies
-        self._preys_step()
+        self.prey_logic.move(self.tick, self.wolf)
+        self.prey_logic.spawn(self.tick, self.wolf)
+        self._next_spawn_tick = self.prey_logic.next_spawn_tick
 
-        # 4) Spawns
-        self._maybe_spawn()
-
-        # 5) Manger APRES déplacement
         if self.hp > 0.0:
             self._eat_if_in_reach()
 
-        # 6) Fin si HP épuisés
-        done = (self.hp <= 0.0)
-        return done
+        return self.hp <= 0.0
+
+
+__all__ = ["SurvivalEnvV2"]

--- a/env_survival.py
+++ b/env_survival.py
@@ -1,100 +1,51 @@
 from __future__ import annotations
-from dataclasses import dataclass
-from typing import List, Tuple, Optional
+
+from typing import Optional, Tuple
+
 import numpy as np
+
 from config import Config
-
-Pos = Tuple[int, int]
-DIRS_8 = [(0,-1),(1,-1),(1,0),(1,1),(0,1),(-1,1),(-1,0),(-1,-1)]
-STAY = (0,0)
-
-
-def in_bounds(p: Pos, n: int) -> bool:
-    return 0 <= p[0] < n and 0 <= p[1] < n
-
-
-def cheb(a: Pos, b: Pos) -> int:
-    return max(abs(a[0]-b[0]), abs(a[1]-b[1]))
-
-
-@dataclass
-class Prey:
-    pos: Pos
+from preys import BasicPreyLogic, Pos
 
 
 class SurvivalEnv:
-    """
-    Environnement minimaliste, sans notion de reward/capture.
-    - State: positions loup + proies, barre de vie, tick.
-    - Step: la politique externe met à jour la position du loup via `set_wolf` avant `step()`.
-      `step()` applique faim, manger si à portée, déplacement des proies (1 tick/2), spawn éventuel.
-    """
+    """Basic survival environment that delegates prey logic to :mod:`preys`."""
+
     def __init__(self, cfg: Config):
         self.cfg = cfg
-
         self.n = cfg.GRID_SIZE
         self.rng = np.random.default_rng(cfg.RNG_SEED)
 
         self.tick: int = 0
-        self.wolf: Pos = (0,0)
+        self.wolf: Pos = (0, 0)
         self.hp: float = float(cfg.HP_MAX)
-        self.preys: List[Prey] = []
         self.score: int = 0
         self._ate_this_tick: bool = False
 
+        self.prey_logic = BasicPreyLogic(cfg, self.rng)
+        self.preys = self.prey_logic.preys
 
-        # spawn scheduler (délai croissant)
-        self._spawn_interval: float = float(cfg.SPAWN_INTERVAL_START)
-        self._next_spawn_tick: int = int(self._spawn_interval)
+        self._next_spawn_tick: int = self.prey_logic.next_spawn_tick
 
-    # --- API contrôle externe du loup ---
-    def set_wolf(self, pos: Pos):
-        x = max(0, min(self.n-1, int(pos[0])))
-        y = max(0, min(self.n-1, int(pos[1])))
+    def set_wolf(self, pos: Pos) -> None:
+        x = max(0, min(self.n - 1, int(pos[0])))
+        y = max(0, min(self.n - 1, int(pos[1])))
         self.wolf = (x, y)
 
-    # --- Reset ---
-
-    def reset(self):
+    def reset(self) -> None:
         self.tick = 0
         self.hp = float(self.cfg.HP_MAX)
-        self.preys = []
         self.score = 0
         self._ate_this_tick = False
 
-
-        # place wolf
         self.wolf = (self.rng.integers(0, self.n), self.rng.integers(0, self.n))
+        self.prey_logic.reset(self.wolf)
+        self._next_spawn_tick = self.prey_logic.next_spawn_tick
 
-        # place initial preys
-        occ = {self.wolf}
-        while len(self.preys) < self.cfg.N_PREYS_START:
-            p = (self.rng.integers(0, self.n), self.rng.integers(0, self.n))
-            if p not in occ:
-                self.preys.append(Prey(p))
-                occ.add(p)
+    def nearest_prey(self, pos: Optional[Pos] = None) -> Tuple[int, Optional[Pos]]:
+        return self.prey_logic.nearest_prey(self.wolf, pos)
 
-        # reset spawn schedule
-        self._spawn_interval = float(self.cfg.SPAWN_INTERVAL_START)
-        self._next_spawn_tick = int(self._spawn_interval)
-
-    # --- Query helpers ---
-    def nearest_prey(self, pos: Optional[Pos] = None) -> tuple[int, Optional[Pos]]:
-        if pos is None:
-            pos = self.wolf
-        if not self.preys:
-            return (10**9, None)
-        best_d = 10**9
-        best_p: Optional[Pos] = None
-        for pr in self.preys:
-            d = cheb(pos, pr.pos)
-            if d < best_d:
-                best_d = d
-                best_p = pr.pos
-        return best_d, best_p
-
-    # --- Eating ---
-    def _apply_heal(self):
+    def _apply_heal(self) -> None:
         missing = float(self.cfg.HP_MAX) - self.hp
         if missing <= 0:
             return
@@ -103,87 +54,32 @@ class SurvivalEnv:
             return
         self.hp = min(float(self.cfg.HP_MAX), self.hp + heal)
 
-    def _eat_if_in_reach(self):
-        """Mange au plus une proie adjacente (distance de Chebyshev <= 1)."""
+    def _eat_if_in_reach(self) -> None:
         if self._ate_this_tick:
             return
-        for idx, prey in enumerate(self.preys):
-            if cheb(self.wolf, prey.pos) <= 1:
-                self.preys.pop(idx)
-                self._apply_heal()
-                self.score += 1
-                self._ate_this_tick = True
-                break
-
-
-    # --- Preys movement (1 tick sur 2) ---
-    def _preys_step(self):
-        if self.cfg.PREY_MOVES_EVERY_OTHER_TICK and (self.tick % 2 == 1):
-            # bougent un tick sur deux (ici: ticks impairs). Change si tu préfères pairs.
+        prey = self.prey_logic.eat_if_in_reach(self.wolf)
+        if prey is None:
             return
-        n = self.n
-        wolf_cell = self.wolf
-        occupied = {pr.pos for pr in self.preys}
-        order = list(range(len(self.preys)))
-        self.rng.shuffle(order)
+        self._apply_heal()
+        self.score += prey.score_value
+        self._ate_this_tick = True
 
-        for idx in order:
-            pr = self.preys[idx]
-            start = pr.pos
-            if self.rng.random() >= self.cfg.PREY_MOVE_PROB:
-                continue
-            candidates = [(start[0]+dx, start[1]+dy) for dx,dy in ([STAY] + DIRS_8)]
-            candidates = [c for c in candidates if in_bounds(c, n) and c != wolf_cell]
-
-            occupied.discard(start)
-            free = [c for c in candidates if c not in occupied]
-            if not free:
-                occupied.add(start)
-                continue
-            choice = free[self.rng.integers(0, len(free))]
-            pr.pos = choice
-            occupied.add(choice)
-
-    # --- Spawn schedule with increasing delay ---
-    def _maybe_spawn(self):
-        if len(self.preys) >= self.cfg.MAX_PREYS:
-            return
-        if self.tick >= self._next_spawn_tick:
-            # spawn une proie sur une case libre
-            occ = {self.wolf, *(pr.pos for pr in self.preys)}
-            tries = 0
-            while tries < 200:
-                tries += 1
-                p = (self.rng.integers(0, self.n), self.rng.integers(0, self.n))
-                if p not in occ:
-                    self.preys.append(Prey(p))
-                    break
-            # planifier prochain spawn (délai croissant)
-            self._spawn_interval = max(1.0, self._spawn_interval * self.cfg.SPAWN_INTERVAL_GROWTH)
-            self._next_spawn_tick = self.tick + int(round(self._spawn_interval))
-
-    # --- Step ---
-
-    def step(self):
+    def step(self) -> bool:
         self.tick += 1
         self._ate_this_tick = False
-        # Décroissance de la vie
+
         self.hp = max(0.0, self.hp - self.cfg.HP_DECAY_PER_TICK)
 
-
-        # Manger AVANT le déplacement des proies
         self._eat_if_in_reach()
 
-        # Mouvement des proies (un tick sur deux)
-        self._preys_step()
+        self.prey_logic.move(self.tick, self.wolf)
+        self.prey_logic.spawn(self.tick, self.wolf)
+        self._next_spawn_tick = self.prey_logic.next_spawn_tick
 
-        # Spawn éventuel (délai croissant)
-        self._maybe_spawn()
-
-        # Manger APRÈS déplacement (au cas où une proie se rapproche)
         self._eat_if_in_reach()
 
-        # Terminaison quand hp tombe à 0
-        done = (self.hp <= 0)
+        done = self.hp <= 0.0
         return done
 
+
+__all__ = ["SurvivalEnv"]

--- a/main.py
+++ b/main.py
@@ -10,15 +10,41 @@ from __future__ import annotations
 import sys
 import pygame
 from config import Config
+from env2_survival import SurvivalEnvV2
 from env_survival import SurvivalEnv
 from renderer import Renderer
-from advanced_wolf_policy import choose_next_pos
+from advanced_wolf_policy import choose_next_pos as advanced_wolf_policy
 from results_logger import log_result
+from wolf_policy import choose_next_pos as basic_wolf_policy
+
+
+def _prompt_mode() -> str:
+    print("Choisissez un mode:")
+    print("  1 - Mode classique (env, politique avancée)")
+    print("  2 - Mode avancé (env2, politique simple)")
+    while True:
+        choice = input("Votre choix (1/2): ").strip()
+        if choice in {"1", "2"}:
+            return choice
+        print("Entrée invalide. Merci de répondre par 1 ou 2.")
+
+
+def _build_game(cfg: Config):
+    choice = _prompt_mode()
+    if choice == "1":
+        print("Mode 1 sélectionné: environnement classique avec politique avancée.")
+        env = SurvivalEnv(cfg)
+        policy = advanced_wolf_policy
+    else:
+        print("Mode 2 sélectionné: environnement avancé avec politique simple.")
+        env = SurvivalEnvV2(cfg)
+        policy = basic_wolf_policy
+    return env, policy
 
 
 def run():
     cfg = Config()
-    env = SurvivalEnv(cfg)
+    env, policy = _build_game(cfg)
     env.reset()
     rnd = Renderer(env, cfg)
 
@@ -38,7 +64,7 @@ def run():
 
             if not paused:
                 # dynamique du loup (externe)
-                next_pos = choose_next_pos(env, env.wolf)
+                next_pos = policy(env, env.wolf)
                 env.set_wolf(next_pos)
 
                 # step environnement

--- a/preys.py
+++ b/preys.py
@@ -1,0 +1,394 @@
+"""Logic related to prey behaviour for the survival environments."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+from config import Config
+
+Pos = Tuple[int, int]
+DIRS_8 = [(0, -1), (1, -1), (1, 0), (1, 1), (0, 1), (-1, 1), (-1, 0), (-1, -1)]
+STAY = (0, 0)
+
+
+def in_bounds(p: Pos, n: int) -> bool:
+    return 0 <= p[0] < n and 0 <= p[1] < n
+
+
+def cheb(a: Pos, b: Pos) -> int:
+    return max(abs(a[0] - b[0]), abs(a[1] - b[1]))
+
+
+@dataclass
+class BasicPrey:
+    pos: Pos
+    score_value: int = 1
+
+
+class BasicPreyLogic:
+    """Encapsulates spawn and movement logic for the basic environment."""
+
+    def __init__(self, cfg: Config, rng: np.random.Generator):
+        self.cfg = cfg
+        self.rng = rng
+        self.n = cfg.GRID_SIZE
+        self.preys: List[BasicPrey] = []
+        self._spawn_interval: float = float(cfg.SPAWN_INTERVAL_START)
+        self._next_spawn_tick: int = int(self._spawn_interval)
+
+    @property
+    def next_spawn_tick(self) -> int:
+        return self._next_spawn_tick
+
+    def reset(self, wolf_pos: Pos) -> None:
+        self.preys = []
+        occ = {wolf_pos}
+        while len(self.preys) < self.cfg.N_PREYS_START:
+            p = (
+                self.rng.integers(0, self.n),
+                self.rng.integers(0, self.n),
+            )
+            if p not in occ:
+                self.preys.append(BasicPrey(p))
+                occ.add(p)
+
+        self._spawn_interval = float(self.cfg.SPAWN_INTERVAL_START)
+        self._next_spawn_tick = int(self._spawn_interval)
+
+    def nearest_prey(self, wolf_pos: Pos, pos: Optional[Pos] = None) -> tuple[int, Optional[Pos]]:
+        if pos is None:
+            pos = wolf_pos
+        if not self.preys:
+            return 10**9, None
+        best_d = 10**9
+        best_p: Optional[Pos] = None
+        for prey in self.preys:
+            d = cheb(pos, prey.pos)
+            if d < best_d:
+                best_d = d
+                best_p = prey.pos
+        return best_d, best_p
+
+    def eat_if_in_reach(self, wolf_pos: Pos) -> Optional[BasicPrey]:
+        for idx, prey in enumerate(self.preys):
+            if cheb(wolf_pos, prey.pos) <= 1:
+                return self.preys.pop(idx)
+        return None
+
+    def move(self, tick: int, wolf_pos: Pos) -> None:
+        if self.cfg.PREY_MOVES_EVERY_OTHER_TICK and (tick % 2 == 1):
+            return
+
+        n = self.n
+        wolf_cell = wolf_pos
+        occupied = {prey.pos for prey in self.preys}
+        order = list(range(len(self.preys)))
+        self.rng.shuffle(order)
+
+        for idx in order:
+            prey = self.preys[idx]
+            start = prey.pos
+            if self.rng.random() >= self.cfg.PREY_MOVE_PROB:
+                continue
+            candidates = [(start[0] + dx, start[1] + dy) for dx, dy in ([STAY] + DIRS_8)]
+            candidates = [c for c in candidates if in_bounds(c, n) and c != wolf_cell]
+
+            occupied.discard(start)
+            free = [c for c in candidates if c not in occupied]
+            if not free:
+                occupied.add(start)
+                continue
+            choice = free[self.rng.integers(0, len(free))]
+            prey.pos = choice
+            occupied.add(choice)
+
+    def spawn(self, tick: int, wolf_pos: Pos) -> None:
+        if len(self.preys) >= self.cfg.MAX_PREYS:
+            return
+        if tick < self._next_spawn_tick:
+            return
+
+        occ = {wolf_pos, *(prey.pos for prey in self.preys)}
+        tries = 0
+        while tries < 200:
+            tries += 1
+            p = (
+                self.rng.integers(0, self.n),
+                self.rng.integers(0, self.n),
+            )
+            if p not in occ:
+                self.preys.append(BasicPrey(p))
+                break
+
+        self._spawn_interval = max(1.0, self._spawn_interval * self.cfg.SPAWN_INTERVAL_GROWTH)
+        self._next_spawn_tick = tick + int(round(self._spawn_interval))
+
+
+# Types de proies avancés
+PREY_STATIC = 0
+PREY_ERRATIC = 1
+PREY_FLEE = 2
+
+PREY_POINTS = {
+    PREY_STATIC: 1,
+    PREY_ERRATIC: 2,
+    PREY_FLEE: 3,
+}
+
+
+@dataclass
+class AdvancedPrey:
+    pos: Pos
+    ptype: int
+    ttl: int
+
+    @property
+    def score_value(self) -> int:
+        return PREY_POINTS.get(self.ptype, 1)
+
+
+class AdvancedPreyLogic:
+    """Extended prey behaviour used by the second environment."""
+
+    def __init__(self, cfg: Config, rng: np.random.Generator):
+        self.cfg = cfg
+        self.rng = rng
+        self.n = cfg.GRID_SIZE
+        self.preys: List[AdvancedPrey] = []
+
+        self._spawn_cycle = [PREY_STATIC, PREY_ERRATIC, PREY_FLEE]
+        self._spawn_idx = 0
+        self._spawn_interval: float = float(cfg.SPAWN_INTERVAL_START)
+        self._next_spawn_tick: int = int(self._spawn_interval)
+
+        self._ttl_static = int(cfg.TTL_STATIC)
+        self._ttl_erratic = int(cfg.TTL_ERRATIC)
+        self._ttl_flee = int(cfg.TTL_FLEE)
+
+    @property
+    def next_spawn_tick(self) -> int:
+        return self._next_spawn_tick
+
+    def reset(self, wolf_pos: Pos) -> None:
+        self.preys = []
+        self._spawn_idx = 0
+
+        occ = {wolf_pos}
+        for _ in range(self.cfg.N_PREYS_START):
+            p = self._sample_free_cell(occ)
+            if p is None:
+                break
+            ptype = self._spawn_cycle[self._spawn_idx]
+            self._spawn_idx = (self._spawn_idx + 1) % len(self._spawn_cycle)
+            ttl = self._initial_ttl_for(ptype)
+            self.preys.append(AdvancedPrey(p, ptype, ttl))
+            occ.add(p)
+
+        self._spawn_interval = float(self.cfg.SPAWN_INTERVAL_START)
+        self._next_spawn_tick = int(self._spawn_interval)
+
+    def _sample_free_cell(self, occupied: set[Pos]) -> Optional[Pos]:
+        tries = 0
+        while tries < 400:
+            tries += 1
+            p = (
+                self.rng.integers(0, self.n),
+                self.rng.integers(0, self.n),
+            )
+            if p not in occupied:
+                return p
+        return None
+
+    def _initial_ttl_for(self, ptype: int) -> int:
+        if ptype == PREY_STATIC:
+            return self._ttl_static
+        if ptype == PREY_ERRATIC:
+            return self._ttl_erratic
+        return self._ttl_flee
+
+    def nearest_prey(self, wolf_pos: Pos, pos: Optional[Pos] = None) -> tuple[int, Optional[Pos]]:
+        if pos is None:
+            pos = wolf_pos
+        if not self.preys:
+            return 10**9, None
+        best_d = 10**9
+        best_p: Optional[Pos] = None
+        for prey in self.preys:
+            d = cheb(pos, prey.pos)
+            if d < best_d:
+                best_d = d
+                best_p = prey.pos
+        return best_d, best_p
+
+    def before_step(self) -> None:
+        i = 0
+        while i < len(self.preys):
+            self.preys[i].ttl -= 1
+            if self.preys[i].ttl <= 0:
+                self.preys.pop(i)
+            else:
+                i += 1
+
+    def eat_if_in_reach(self, wolf_pos: Pos) -> Optional[AdvancedPrey]:
+        for idx, prey in enumerate(self.preys):
+            if cheb(wolf_pos, prey.pos) <= 1:
+                return self.preys.pop(idx)
+        return None
+
+    def move(self, tick: int, wolf_pos: Pos) -> None:
+        n = self.n
+        wolf_cell = wolf_pos
+
+        occupied = {prey.pos for prey in self.preys}
+        order = list(range(len(self.preys)))
+        self.rng.shuffle(order)
+
+        for idx in order:
+            prey = self.preys[idx]
+            start = prey.pos
+
+            if prey.ptype == PREY_STATIC:
+                continue
+
+            if prey.ptype == PREY_ERRATIC:
+                if self.cfg.PREY_MOVES_EVERY_OTHER_TICK and (tick % 2 == 1):
+                    continue
+            else:
+                if (tick % self.cfg.FLEE_MOVE_PERIOD) == self.cfg.FLEE_MOVE_REST_PHASE:
+                    continue
+
+            if self.rng.random() >= self.cfg.PREY_MOVE_PROB:
+                continue
+
+            occupied.discard(start)
+
+            if prey.ptype == PREY_ERRATIC:
+                new_pos = self._step_erratic(start, wolf_cell, occupied, n)
+            else:
+                if cheb(start, wolf_cell) <= self.cfg.FLEE_RADIUS:
+                    new_pos = self._step_flee(start, wolf_cell, occupied, n)
+                else:
+                    new_pos = self._step_erratic(start, wolf_cell, occupied, n)
+
+            if new_pos is None:
+                if start != wolf_cell and start not in occupied:
+                    prey.pos = start
+                    occupied.add(start)
+                else:
+                    candidates = [
+                        (start[0] + dx, start[1] + dy)
+                        for dx, dy in ([STAY] + DIRS_8)
+                        if in_bounds((start[0] + dx, start[1] + dy), n)
+                        and (start[0] + dx, start[1] + dy) != wolf_cell
+                        and (start[0] + dx, start[1] + dy) not in occupied
+                    ]
+                    if candidates:
+                        choice = candidates[self.rng.integers(0, len(candidates))]
+                        prey.pos = choice
+                        occupied.add(choice)
+                    else:
+                        prey.pos = start
+                        occupied.add(start)
+            else:
+                prey.pos = new_pos
+                occupied.add(new_pos)
+
+    def _step_erratic(
+        self, start: Pos, wolf: Pos, occupied: set[Pos], n: int
+    ) -> Optional[Pos]:
+        candidates = [
+            (start[0] + dx, start[1] + dy)
+            for dx, dy in ([STAY] + DIRS_8)
+            if in_bounds((start[0] + dx, start[1] + dy), n)
+            and (start[0] + dx, start[1] + dy) != wolf
+            and (start[0] + dx, start[1] + dy) not in occupied
+        ]
+        if not candidates:
+            return None
+        return candidates[self.rng.integers(0, len(candidates))]
+
+    def _step_flee(
+        self, start: Pos, wolf: Pos, occupied: set[Pos], n: int
+    ) -> Optional[Pos]:
+        vx = _sign(start[0] - wolf[0])
+        vy = _sign(start[1] - wolf[1])
+        if vx == 0 and vy == 0:
+            return self._step_erratic(start, wolf, occupied, n)
+
+        primary = (start[0] + vx, start[1] + vy)
+        if in_bounds(primary, n) and primary not in occupied and primary != wolf:
+            return primary
+
+        candidates: List[Pos] = []
+        if not in_bounds((start[0] + vx, start[1]), n):
+            for vy2 in (-1, 1):
+                alt = (start[0], start[1] + vy2)
+                if in_bounds(alt, n) and alt not in occupied and alt != wolf:
+                    candidates.append(alt)
+        if not in_bounds((start[0], start[1] + vy), n):
+            for vx2 in (-1, 1):
+                alt = (start[0] + vx2, start[1])
+                if in_bounds(alt, n) and alt not in occupied and alt != wolf:
+                    candidates.append(alt)
+
+        if candidates:
+            return candidates[self.rng.integers(0, len(candidates))]
+
+        better: List[Pos] = []
+        same: List[Pos] = []
+        d0 = cheb(start, wolf)
+        for dx, dy in DIRS_8 + [STAY]:
+            alt = (start[0] + dx, start[1] + dy)
+            if not in_bounds(alt, n) or alt == wolf or alt in occupied:
+                continue
+            d = cheb(alt, wolf)
+            if d > d0:
+                better.append(alt)
+            elif d == d0:
+                same.append(alt)
+        pool = better if better else same
+        if pool:
+            return pool[self.rng.integers(0, len(pool))]
+        return None
+
+    def spawn(self, tick: int, wolf_pos: Pos) -> None:
+        if len(self.preys) >= self.cfg.MAX_PREYS:
+            return
+        if tick < self._next_spawn_tick:
+            return
+
+        occ = {wolf_pos, *(prey.pos for prey in self.preys)}
+        p = self._sample_free_cell(occ)
+        if p is not None:
+            ptype = self._spawn_cycle[self._spawn_idx]
+            self._spawn_idx = (self._spawn_idx + 1) % len(self._spawn_cycle)
+            ttl = self._initial_ttl_for(ptype)
+            self.preys.append(AdvancedPrey(p, ptype, ttl))
+
+        self._spawn_interval = max(1.0, self._spawn_interval * self.cfg.SPAWN_INTERVAL_GROWTH)
+        self._next_spawn_tick = tick + int(round(self._spawn_interval))
+
+
+def _sign(x: int) -> int:
+    if x == 0:
+        return 0
+    return 1 if x > 0 else -1
+
+
+__all__ = [
+    "AdvancedPrey",
+    "AdvancedPreyLogic",
+    "BasicPrey",
+    "BasicPreyLogic",
+    "DIRS_8",
+    "PREY_ERRATIC",
+    "PREY_FLEE",
+    "PREY_POINTS",
+    "PREY_STATIC",
+    "STAY",
+    "cheb",
+    "in_bounds",
+]

--- a/renderer.py
+++ b/renderer.py
@@ -7,14 +7,25 @@ Created on Wed Oct  1 20:48:14 2025
 
 from __future__ import annotations
 import pygame
-from typing import Tuple
-from config import Config
-from env_survival import SurvivalEnv
+from typing import Protocol, Sequence, Tuple
 
-Color = Tuple[int,int,int]
+from config import Config
+from preys import Pos
+
+Color = Tuple[int, int, int]
+
+
+class SupportsRenderEnv(Protocol):
+    n: int
+    preys: Sequence
+    wolf: Pos
+    hp: float
+    tick: int
+    score: int
+
 
 class Renderer:
-    def __init__(self, env: SurvivalEnv, cfg: Config):
+    def __init__(self, env: SupportsRenderEnv, cfg: Config):
         self.env = env
         self.cfg = cfg
         pygame.init()

--- a/wolf_policy.py
+++ b/wolf_policy.py
@@ -6,15 +6,20 @@ Created on Wed Oct  1 20:48:40 2025
 """
 
 from __future__ import annotations
-from typing import Tuple
-from env_survival import SurvivalEnv, cheb
 
-Pos = Tuple[int,int]
+from typing import Optional, Protocol, Tuple
 
-# === API à implémenter/itérer par toi ===
-# Retourne la prochaine position du loup (bornée par l'env).
+from preys import Pos
 
-def choose_next_pos(env: SurvivalEnv, prev_pos: Pos) -> Pos:
+
+class SupportsWolfEnv(Protocol):
+    n: int
+
+    def nearest_prey(self, pos: Optional[Pos] = None) -> Tuple[int, Optional[Pos]]:
+        ...
+
+
+def choose_next_pos(env: SupportsWolfEnv, prev_pos: Pos) -> Pos:
     """Politique placeholder : aller (bêtement) vers la proie la plus proche.
     Remplace par ta dynamique (RL, heuristique, etc.).
     """


### PR DESCRIPTION
## Summary
- move prey-related configuration flags into `Config` and expose shared constants for both environments
- centralize prey behaviours in a new `preys` module that powers the classic and advanced survival environments
- prompt players to pick environment v1 or v2 at launch while adapting renderer and policies to the shared interfaces

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68ddbed194508323a2d41b28d5f519b7